### PR TITLE
dcpdig @upload validation -> batch job -> cloudwatch log

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,31 +16,94 @@ DCP to allow it to walk the object graph.
 
 ### Usage
 
-Usage: `dcpdig @<component> <expression> --show <entities_to_show>`
+Usage: `dcpdig --deployment=<deployment> @<component> <expression> --show <entities_to_show>`
+
+#### Usage with the Ingestion Service
+
+Use component `@ingest`.
+
+Expressions:
+
+```
+submission_id=<mongo-id>
+submission_uuid=<uuid>
+project_uuid=<uuid>
+bundle_uuid=<uuid>
+```
+
+Abbreviations that may be used in expressions:
+
+* `summission` may be abbreviated to `subm`, e.g. `subm_uuid`.
+* `project` may be abbreviated to `proj`.
+
+Entities:
+
+```
+submissions
+bundles
+files
+```
 
 Examples:
 
-Find the submission relating to a DSS bundle UUID:
+Given a project UUID from the integration environment, show submissions
+and their bundles and files:
 
-    dcpdig @ingest bundle_uuid=<x>
+    dcpdig -d integration @ingest proj_uuid=<uuid> --show all
 
 Find a (Mongo) submission ID given a submission UUID:
 
-    dcpdig @ingest submission_uuid=<x>
+    dcpdig -d staging @ingest submission_uuid=<x>
 
-Note that submission may be abbreviated to "subm" or "sub", e.g.
-`subm_uuid=x`.
+Show bundles associated with an Ingest submission with Mongo ID `foo`:
 
-Show files and bundles associated with an Ingest submission with Mongo ID `foo`:
+    dcpdig -d dev @ingest subm_id=foo --show bundles
 
-    dcpdig @ingest subm_id=foo --show files,bundles
+Find the submission relating to a DSS bundle UUID.  This does a "brute
+force" search through all submissions to find the one using this bundle:
 
-Show Upload Area records for area, files, checksums, validations and
-notifications including payloads (verbose mode):
+    dcpdig -d dev @ingest bundle_uuid=<x>
 
-    dcpdig @upload area=<uuid> --show all --verbose
+#### Usage with the Upload Service
+
+Use component `@upload`.
+
+Expressions:
+
+```
+area=<uuid>
+file_id=<uuid>/<filename>
+validation_id=<uuid>
+batch_job=<uuid>
+```
+
+Entities:
+
+```
+files
+checksums
+validations
+notifications
+batch_jobs
+logs
+```
+or use `all`
+
+Permisions: you must be using AWS credentials (typically an AWS_PROFILE)
+that has access to the Upload Service secrets in AWS SecretsManager.
+Most DCP developers has this level of access.
+
+Examples:
+
+Exhaustively dump everything associated with an upload area, verbosely.
+This can be very long:
+
+    dcpdig @upload area=<uuid> --show all -v
 
 Show file, checksum records for a single file:
 
     dcpdig @upload file_id=<uuid>/<filename> --show checksums
 
+Show validation, batch job records and job log:
+
+    dcpdig @upload validation_id=<uuid> --show batch_jobs,logs

--- a/dcp_diag/component_agents/__init__.py
+++ b/dcp_diag/component_agents/__init__.py
@@ -1,4 +1,35 @@
+from abc import abstractmethod
+
 from .data_store_agent import DataStoreAgent
 from .ingest_api_agent import IngestApiAgent
 from .ingest_auth_agent import IngestAuthAgent
 from .ingest_ui_agent import IngestUIAgent
+
+
+class EntityBase:
+
+    @abstractmethod
+    def __str__(self, prefix=""):
+        """Return a textual representation of this entity
+
+        :param prefix: must be output at the start of each line out output
+        :return: a string
+
+        example:
+
+        def __str__(self, prefix=""):
+          return colored(f"MyEntity {self.id}", 'red') + \
+          f"{prefix}    attr1: {self.attr1}\n" + \
+          f"{prefix}    attr2: {self.attr2}\n"
+        """
+
+    @abstractmethod
+    def print(self, prefix="", verbose=False, associated_entities_to_show=None):
+        """Display textual representation of this entity and optionally, associated ones.
+
+        :param prefix: must be output at the start of each line out output
+        :param verbose: display verbose output, pass this on to other entities
+        :param associated_entities_to_show: an array of strings, each of which is an entity name, e.g. "file"
+               that should also be displayed
+        :return: nothing
+        """

--- a/dcp_diag/component_agents/upload_entities.py
+++ b/dcp_diag/component_agents/upload_entities.py
@@ -7,6 +7,8 @@ from termcolor import colored
 
 from dcplib.config import Config
 
+from . import EntityBase
+
 DbBase = declarative_base(name='DbBase')
 
 
@@ -27,7 +29,7 @@ class DBSessionMaker:
         return self.session_maker()
 
 
-class DbUploadArea(DbBase):
+class DbUploadArea(DbBase, EntityBase):
     __tablename__ = 'upload_area'
     id = Column(String(), primary_key=True)
     bucket_name = Column(String(), nullable=False)
@@ -36,20 +38,22 @@ class DbUploadArea(DbBase):
     updated_at = Column(DateTime, default=datetime.utcnow, nullable=False, onupdate=datetime.utcnow)
 
     def __str__(self, prefix="", verbose=False):
-        return colored(f"{prefix}Upload Area {self.id}\n", 'green') + \
+        return colored(f"{prefix}Upload Area {self.id}\n", 'blue') + \
             f"{prefix}    bucket_name: {self.bucket_name}\n" \
             f"{prefix}         Status: {self.status}\n" \
             f"{prefix}     created_at: {self.created_at}\n" \
             f"{prefix}     updated_at: {self.updated_at}\n"
 
-    def show_associated(self, entities_to_show, prefix="", verbose=False):
-        if 'files' in entities_to_show or 'all' in entities_to_show:
-            for file in self.files:
-                print(file.__str__(prefix=prefix, verbose=verbose))
-                file.show_associated(entities_to_show, prefix="\t\t", verbose=verbose)
+    def print(self, prefix="", verbose=False, associated_entities_to_show=None):
+        print(self.__str__(prefix=prefix, verbose=verbose))
+        if associated_entities_to_show:
+            if 'files' in associated_entities_to_show or 'all' in associated_entities_to_show:
+                prefix = f"\t{prefix}"
+                for file in self.files:
+                    file.print(prefix=prefix, verbose=verbose, associated_entities_to_show=associated_entities_to_show)
 
 
-class DbFile(DbBase):
+class DbFile(DbBase, EntityBase):
     __tablename__ = 'file'
     id = Column(String(), primary_key=True)
     upload_area_id = Column(String(), ForeignKey('upload_area.id'), nullable=False)
@@ -68,19 +72,25 @@ class DbFile(DbBase):
             f"{prefix}        created_at: {self.created_at}\n" \
             f"{prefix}        updated_at: {self.updated_at}\n"
 
-    def show_associated(self, entities_to_show, prefix="", verbose=False):
-        if 'checksums' in entities_to_show or 'all' in entities_to_show:
-            for checksum in self.checksums:
-                print(checksum.__str__(prefix=prefix, verbose=verbose))
-        if 'validations' in entities_to_show or 'all' in entities_to_show:
-            for val in self.validations:
-                print(val.__str__(prefix=prefix, verbose=verbose))
-        if 'notifications' in entities_to_show or 'all' in entities_to_show:
-            for notif in self.notifications:
-                print(notif.__str__(prefix=prefix, verbose=verbose))
+    def print(self, prefix="", verbose=False, associated_entities_to_show=None):
+        print(self.__str__(prefix=prefix, verbose=verbose))
+        if associated_entities_to_show:
+            prefix = f"\t{prefix}"
+            if 'checksums' in associated_entities_to_show or 'all' in associated_entities_to_show:
+                for checksum in self.checksums:
+                    checksum.print(prefix=prefix, verbose=verbose,
+                                   associated_entities_to_show=associated_entities_to_show)
+            if 'validations' in associated_entities_to_show or 'all' in associated_entities_to_show:
+                for val in self.validations:
+                    val.print(prefix=prefix, verbose=verbose,
+                              associated_entities_to_show=associated_entities_to_show)
+            if 'notifications' in associated_entities_to_show or 'all' in associated_entities_to_show:
+                for notif in self.notifications:
+                    notif.print(prefix=prefix, verbose=verbose,
+                                associated_entities_to_show=associated_entities_to_show)
 
 
-class DbChecksum(DbBase):
+class DbChecksum(DbBase, EntityBase):
     __tablename__ = 'checksum'
     id = Column(String(), primary_key=True)
     file_id = Column(String(), ForeignKey('file.id'), nullable=False)
@@ -95,7 +105,7 @@ class DbChecksum(DbBase):
     file = relationship("DbFile", back_populates='checksums')
 
     def __str__(self, prefix="", verbose=False):
-        output = colored(f"{prefix}Checksum {self.id}\n", 'blue') + \
+        output = colored(f"{prefix}Checksum {self.id}\n", 'cyan') + \
                  f"{prefix}                File ID: {self.file_id}\n" \
                  f"{prefix}                 Job ID: {self.job_id}\n" \
                  f"{prefix}                 Status: {self.status}\n" \
@@ -107,8 +117,11 @@ class DbChecksum(DbBase):
             output = output + f"{prefix}              checksums: {self.checksums}\n"
         return output
 
+    def print(self, prefix="", verbose=False, associated_entities_to_show=None):
+        print(self.__str__(prefix=prefix, verbose=verbose))
 
-class DbNotification(DbBase):
+
+class DbNotification(DbBase, EntityBase):
     __tablename__ = 'notification'
     id = Column(String(), primary_key=True)
     file_id = Column(String(), ForeignKey('file.id'), nullable=False)
@@ -120,7 +133,7 @@ class DbNotification(DbBase):
     file = relationship("DbFile", back_populates='notifications')
 
     def __str__(self, prefix="", verbose=False):
-        output = colored(f"{prefix}Notification {self.id}\n", 'blue') + \
+        output = colored(f"{prefix}Notification {self.id}\n", 'magenta') + \
                  f"{prefix}       File ID: {self.file_id}\n" \
                  f"{prefix}        Status: {self.status}\n" \
                  f"{prefix}    created_at: {self.created_at}\n" \
@@ -129,8 +142,11 @@ class DbNotification(DbBase):
             output = output + f"{prefix}       payload: {self.payload}\n"
         return output
 
+    def print(self, prefix="", verbose=False, associated_entities_to_show=None):
+        print(self.__str__(prefix=prefix, verbose=verbose))
 
-class DbValidation(DbBase):
+
+class DbValidation(DbBase, EntityBase):
     __tablename__ = 'validation'
     id = Column(String(), primary_key=True)
     file_id = Column(String(), ForeignKey('file.id'), nullable=False)
@@ -145,7 +161,7 @@ class DbValidation(DbBase):
     file = relationship("DbFile", back_populates='validations')
 
     def __str__(self, prefix="", verbose=False):
-        output = colored(f"{prefix}Validation {self.id}\n", 'blue') + \
+        output = colored(f"{prefix}Validation {self.id}\n", 'yellow') + \
                  f"{prefix}                  File ID: {self.file_id}\n" \
                  f"{prefix}                   Job ID: {self.job_id}\n" \
                  f"{prefix}                   Status: {self.status}\n" \
@@ -156,6 +172,9 @@ class DbValidation(DbBase):
         if verbose:
             output = output + f"{prefix}                  results: {self.results}\n"
         return output
+
+    def print(self, prefix="", verbose=False, associated_entities_to_show=None):
+        print(self.__str__(prefix=prefix, verbose=verbose))
 
 
 DbUploadArea.files = relationship('DbFile', order_by=DbFile.id, back_populates='upload_area')

--- a/dcp_diag/component_agents/upload_entities.py
+++ b/dcp_diag/component_agents/upload_entities.py
@@ -5,11 +5,10 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 from termcolor import colored
 
+DbBase = declarative_base(name='DbBase')
 
-Base = declarative_base()
 
-
-class DbUploadArea(Base):
+class DbUploadArea(DbBase):
     __tablename__ = 'upload_area'
     id = Column(String(), primary_key=True)
     bucket_name = Column(String(), nullable=False)
@@ -31,7 +30,7 @@ class DbUploadArea(Base):
                 file.show_associated(entities_to_show, prefix="\t\t", verbose=verbose)
 
 
-class DbFile(Base):
+class DbFile(DbBase):
     __tablename__ = 'file'
     id = Column(String(), primary_key=True)
     upload_area_id = Column(String(), ForeignKey('upload_area.id'), nullable=False)
@@ -62,7 +61,7 @@ class DbFile(Base):
                 print(notif.__str__(prefix=prefix, verbose=verbose))
 
 
-class DbChecksum(Base):
+class DbChecksum(DbBase):
     __tablename__ = 'checksum'
     id = Column(String(), primary_key=True)
     file_id = Column(String(), ForeignKey('file.id'), nullable=False)
@@ -90,7 +89,7 @@ class DbChecksum(Base):
         return output
 
 
-class DbNotification(Base):
+class DbNotification(DbBase):
     __tablename__ = 'notification'
     id = Column(String(), primary_key=True)
     file_id = Column(String(), ForeignKey('file.id'), nullable=False)
@@ -112,7 +111,7 @@ class DbNotification(Base):
         return output
 
 
-class DbValidation(Base):
+class DbValidation(DbBase):
     __tablename__ = 'validation'
     id = Column(String(), primary_key=True)
     file_id = Column(String(), ForeignKey('file.id'), nullable=False)
@@ -148,7 +147,7 @@ DbFile.notifications = relationship('DbNotification', order_by=DbNotification.cr
 
 def init_db(database_uri):
     engine = create_engine(database_uri)
-    Base.metadata.bind = engine
+    DbBase.metadata.bind = engine
     db_session_maker = sessionmaker()
     db_session_maker.bind = engine
     return db_session_maker

--- a/dcp_diag/finders/upload_finder.py
+++ b/dcp_diag/finders/upload_finder.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from .. import DcpDiagException
 from .finder import Finder
-from ..component_agents.upload_entities import DbUploadArea, DbFile, DBSessionMaker
+from ..component_agents.upload_entities import DbUploadArea, DbFile, DbValidation, BatchJob, DBSessionMaker
 
 
 class UploadFinder:
@@ -21,20 +21,33 @@ class UploadFinder:
         field_name, field_value = expression.split('=')
         db = DBSessionMaker(self.deployment).session()
 
-        if field_name == 'file_id':
+        if field_name == 'file_id' or field_name == 'file':
             try:
                 file = db.query(DbFile).filter(DbFile.id == field_value).one()
                 return file
             except NoResultFound:
                 raise DcpDiagException(f"No record of File \"{field_value}\""
                                        f" found in Upload's {self.deployment} database.")
-        elif field_name == 'area':
+
+        elif field_name == 'area_id' or field_name == 'area':
             try:
                 area = db.query(DbUploadArea).filter(DbUploadArea.id == field_value).one()
                 return area
             except NoResultFound:
                 raise DcpDiagException(f"No record of Upload Area \"{field_value}\""
                                        f" found in Upload's {self.deployment} database.")
+
+        elif field_name == 'validation_id' or field_name == 'validation':
+            try:
+                validation = db.query(DbValidation).filter(DbValidation.id == field_value).one()
+                return validation
+            except NoResultFound:
+                raise DcpDiagException(f"No record of Validation \"{field_value}\""
+                                       f" found in Upload's {self.deployment} database.")
+
+        elif field_name == 'batch_job' or field_name == 'job_id':
+            return BatchJob.find_by_id(field_value)
+
         else:
             raise DcpDiagException(f"Sorry I don't know how to find an {field_name}")
 

--- a/dcp_diag/finders/upload_finder.py
+++ b/dcp_diag/finders/upload_finder.py
@@ -35,6 +35,8 @@ class UploadFinder:
             except NoResultFound:
                 raise DcpDiagException(f"No record of Upload Area \"{field_value}\""
                                        f" found in Upload's {self.deployment} database.")
+        else:
+            raise DcpDiagException(f"Sorry I don't know how to find an {field_name}")
 
 
 Finder.register(UploadFinder)

--- a/dcp_diag/finders/upload_finder.py
+++ b/dcp_diag/finders/upload_finder.py
@@ -1,15 +1,8 @@
 from sqlalchemy.orm.exc import NoResultFound
 
-from dcplib.config import Config
-
 from .. import DcpDiagException
 from .finder import Finder
-from ..component_agents.upload_entities import DbUploadArea, DbFile, init_db
-
-
-class UploadDbConfig(Config):
-    def __init__(self, *args, **kwargs):
-        super().__init__(component_name='upload', secret_name='database', **kwargs)
+from ..component_agents.upload_entities import DbUploadArea, DbFile, DBSessionMaker
 
 
 class UploadFinder:
@@ -26,8 +19,7 @@ class UploadFinder:
 
     def find(self, expression):
         field_name, field_value = expression.split('=')
-        db_session_maker = init_db(UploadDbConfig(deployment=self.deployment).database_uri)
-        db = db_session_maker()
+        db = DBSessionMaker(self.deployment).session()
 
         if field_name == 'file_id':
             try:

--- a/scripts/dcpdig
+++ b/scripts/dcpdig
@@ -38,8 +38,7 @@ class DcpDig:
         try:
             finder = Finder.factory(finder_name=args.component, deployment=self.deployment)
             entity = finder.find(args.expression)
-            print(entity)
-            entity.show_associated(entities_to_show, prefix="\t", verbose=args.verbose)
+            entity.print(verbose=args.verbose, associated_entities_to_show=entities_to_show)
         except DcpDiagException as e:
             print("\n" + str(e))
         except KeyboardInterrupt:


### PR DESCRIPTION
```
dcpdig @upload validation_id=<uuid> --show batch_jobs,logs
dcpdig @upload batch_job=<uuid> --show logs
```
or of course:
```
dcpdig @upload file_id=<uuid>/<filename> --show all
```

Note also the refactoring.  There is now a base class `EntityBase` that defines the interface that entities must implement.  `show_associated` has gone away and you must now implement `print` which prints both the entity and associated entities.